### PR TITLE
SlteRIL: Fix incoming call name presentation

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/SlteRIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/SlteRIL.java
@@ -212,7 +212,8 @@ public class SlteRIL extends RIL {
             if (RILJ_LOGV) {
                 riljLog("responseCallList dc.name=" + dc.name);
             }
-            dc.namePresentation = p.readInt();
+            // according to ril.h, namePresentation should be handled as numberPresentation;
+            dc.namePresentation = DriverCall.presentationFromCLIP(p.readInt());
 
             int uusInfoPresent = p.readInt();
             if (uusInfoPresent == 1) {


### PR DESCRIPTION
According to ril.h, namePresention should be handled as
numberPresention as they are using same value scope. In RIL.java,
only numberPresention is matched to that definition in DriveCall,
 but namePresention is not matched.

Original Commit: https://github.com/CyanogenMod/android_frameworks_opt_telephony/commit/004f70095ae49451757f89dfafce2b26294a5f32

Change-Id: I7dbb18304c7f737fc246ebf2479ada41c3f2e947